### PR TITLE
fix: remove group install - just install deepin-picker

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -25,32 +25,4 @@ RUN /tmp/build.sh && \
     mkdir -p /var/tmp && \
     chmod -R 1777 /var/tmp
 
-FROM fedora:38 as deepinList
-
-RUN dnf group info \
-        'Administration Tools' \
-        'Common NetworkManager Submodules' \
-        'Core' \
-        'Deepin Desktop Environment' \
-	'Dial-up Networking Support' \
-	'Fonts' \
-	'Guest Desktop Agents' \
-	'Hardware Support' \
-	'Input Methods' \
-	'Multimedia' \
-	'Printing Support' \
-	'Standard' \
-	'base-x' \
-    | awk '/^  /' \
-    | xargs dnf group info -v  2>/dev/null \
-    | awk '($2 == "fedora" || $2 == "updates" || $2 == "@System") && ($1 ~ /noarch/ || $1 ~ /x86_64/){print $1}' \
-    |  awk 'NF -= 2{$0=$0; print}' FS='-' OFS='-' \
-    | tee /deepin.txt
-
-FROM builder
-
-COPY --from=deepinList /deepin.txt /tmp/deepin.txt
-
-RUN xargs -a /tmp/deepin.txt rpm-ostree install \
-    && rm -rf /var/*
 RUN ostree container commit

--- a/packages.json
+++ b/packages.json
@@ -2,6 +2,7 @@
     "all": {
         "include": {
             "all": [
+		"deepin-picker",
 		"pulseaudio",
                 "deepin-api",
                 "dtkwm",


### PR DESCRIPTION
The group install makes it so DNFDragora and Chromium get installed. 

DNFDragora doesn't work at all, and chromium is unnecessary on a base image